### PR TITLE
Fix Dithering setting saving

### DIFF
--- a/Gamecube/GamecubeMain.cpp
+++ b/Gamecube/GamecubeMain.cpp
@@ -106,6 +106,7 @@ char biosDevice;
 char LoadCdBios=0;
 char frameLimit;
 char frameSkip;
+char useDithering;
 extern char audioEnabled;
 char volume;
 char showFPSonScreen;
@@ -170,6 +171,7 @@ static struct {
   { "BootThruBios", &LoadCdBios, BOOTTHRUBIOS_NO, BOOTTHRUBIOS_YES },
   { "LimitFrames", &frameLimit, FRAMELIMIT_NONE, FRAMELIMIT_AUTO },
   { "SkipFrames", &frameSkip, FRAMESKIP_DISABLE, FRAMESKIP_ENABLE },
+  { "Dithering", &useDithering, USEDITHER_NONE, USEDITHER_ALWAYS },
   { "PadAutoAssign", &padAutoAssign, PADAUTOASSIGN_MANUAL, PADAUTOASSIGN_AUTOMATIC },
   { "PadType1", &padType[0], PADTYPE_NONE, PADTYPE_WII },
   { "PadType2", &padType[1], PADTYPE_NONE, PADTYPE_WII },
@@ -208,7 +210,7 @@ void loadSettings(int argc, char *argv[])
 	printToSD        = 0; // Disable SD logging
 	frameLimit		 = 1; // Auto limit FPS
 	frameSkip		 = 0; // Disable frame skipping
-	iUseDither		 = 1; // Default dithering
+	useDithering		 = 1; // Default dithering (set to 0 (disabled) in PEOPSgpu)
 	saveEnabled      = 0; // Don't save game
 	nativeSaveDevice = 0; // SD
 	saveStateDevice	 = 0; // SD
@@ -360,6 +362,7 @@ void loadSettings(int argc, char *argv[])
 
 	//Synch settings with Config
 	Config.Cpu=dynacore;
+	iUseDither = useDithering;
 	iVolume = volume;
 }
 

--- a/Gamecube/menu/SettingsFrame.cpp
+++ b/Gamecube/menu/SettingsFrame.cpp
@@ -1136,6 +1136,7 @@ void Func_DitheringNone()
 		FRAME_BUTTONS[i].button->setSelected(false);
 	FRAME_BUTTONS[25].button->setSelected(true);
 	iUseDither = USEDITHER_NONE;
+	useDithering = iUseDither;
 	GPUsetframelimit(0);
 }
 
@@ -1145,6 +1146,7 @@ void Func_DitheringDefault()
 		FRAME_BUTTONS[i].button->setSelected(false);
 	FRAME_BUTTONS[26].button->setSelected(true);
 	iUseDither = USEDITHER_DEFAULT;
+	useDithering = iUseDither;
 	GPUsetframelimit(0);
 }
 
@@ -1154,6 +1156,7 @@ void Func_DitheringAlways()
 		FRAME_BUTTONS[i].button->setSelected(false);
 	FRAME_BUTTONS[27].button->setSelected(true);
 	iUseDither = USEDITHER_ALWAYS;
+	useDithering = iUseDither;
 	GPUsetframelimit(0);
 }
 

--- a/Gamecube/wiiSXconfig.h
+++ b/Gamecube/wiiSXconfig.h
@@ -90,6 +90,7 @@ enum frameSkip
 };
 
 extern int iUseDither;
+extern char useDithering;
 enum iUseDither
 {
 	USEDITHER_NONE=0,

--- a/PeopsSoftGPU/cfg.c
+++ b/PeopsSoftGPU/cfg.c
@@ -333,7 +333,7 @@ void ReadConfig(void)
  dwCfgFixes=0;
  iUseFixes=0;
  iUseNoStretchBlt=1;
- iUseDither=0;
+ iUseDither = useDithering;
  iShowFPS=0;
  bSSSPSXLimit=FALSE;
 


### PR DESCRIPTION
This issue has always plagued WiiStation and its previous emulators which this one is based (WiiSX/-R/-RX), and i was always upset with that bug, so i decided to finally take the situation of this in my hands and after a lot of trial and error, i finally fixed it.

Now when you hit Save settings after changing the Dithering setting, the Dithering setting will be saved as it should be and will be loaded the next time you start the emulator.

The "Default" setting will be the same like this emulator started (Default = no dithering).